### PR TITLE
Added ready development environment for Lando and DDEV

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,61 @@
+APIVersion: v0.20.0
+name: dnorge
+type: drupal8
+docroot: "html/"
+php_version: "7.1"
+router_http_port: "8000"
+router_https_port: "8443"
+xdebug_enabled: true
+additional_hostnames: []
+provider: default
+
+
+# This config.yaml was created with ddev version v0.20.0 
+# webimage: drud/nginx-php-fpm-local:v0.20.0
+# dbimage: drud/mariadb-local:v0.20.0
+# dbaimage: drud/phpmyadmin:v0.20.0
+# However we do not recommend explicitly wiring these images into the
+# config.yaml as they may break future versions of ddev.
+# You can update this config.yaml using 'ddev config'.
+
+# Key features of ddev's config.yaml:
+
+# name: <projectname> # Name of the project, automatically provides 
+#   http://projectname.ddev.local and https://projectname.ddev.local
+
+# type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
+
+# docroot: <relative_path> # Relative path to the directory containing index.php.
+
+# php_version: "7.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2"
+
+# You can explicitly specify the webimage, dbimage, dbaimage lines but this 
+# is not recommended, as the images are often closely tied to ddev's' behavior,
+# so this can break upgrades.
+
+# webimage: <docker_image>  # nginx/php docker image. 
+# dbimage: <docker_image>  # mariadb docker image. 
+# dbaimage: <docker_image>
+
+# router_http_port: <port>  # Port to be used for http (defaults to port 80)
+# router_https_port: <port> # Port for https (defaults to 443)
+
+# xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
+
+#additional_hostnames:
+# - somename
+# - someothername
+# would provide http and https URLs for "somename.ddev.local"
+# and "someothername.ddev.local".
+
+# provider: default # Currently either "default" or "pantheon"
+#
+# Many ddev commands can be extended to run tasks after the ddev command is
+# executed.
+# See https://ddev.readthedocs.io/en/latest/users/extending-commands/ for more
+# information on the commands that can be extended and the tasks you can define
+# for them. Example:
+#hooks:
+# post-import-db:
+#   - exec: drush cr
+#   - exec: drush updb

--- a/.ddev/nginx-site.conf
+++ b/.ddev/nginx-site.conf
@@ -1,0 +1,126 @@
+# ddev drupal8 config
+
+# You can override ddev's configuration by placing an edited copy
+# of this config (or one of the other ones) in .ddev/nginx-site.conf
+# See https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-nginx-configuration
+
+# Set https to 'on' if x-forwarded-proto is https
+map $http_x_forwarded_proto $fcgi_https {
+    default off;
+    https on;
+}
+
+server {
+    listen 80; ## listen for ipv4; this line is default and implied
+    listen [::]:80 default ipv6only=on; ## listen for ipv6
+    # The NGINX_DOCROOT variable is substituted with
+    # its value when the container is started.
+    root $NGINX_DOCROOT;
+    index index.php index.htm index.html;
+
+    # Make site accessible from http://localhost/
+    server_name _;
+
+    # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
+    sendfile off;
+    error_log /var/log/nginx/error.log info;
+    access_log /var/log/nginx/access.log;
+
+    location / {
+        absolute_redirect off;
+        try_files $uri /index.php?$query_string; # For Drupal >= 7
+    }
+
+    location @rewrite {
+        # For D7 and above:
+        # Clean URLs are handled in drupal_environment_initialize().
+        rewrite ^ /index.php;
+    }
+
+    # Handle image styles for Drupal 7+
+    location ~ ^/sites/.*/files/styles/ {
+        try_files $uri @rewrite;
+    }
+
+    # pass the PHP scripts to FastCGI server listening on socket
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_intercept_errors on;
+        # fastcgi_read_timeout should match max_execution_time in php.ini
+        fastcgi_read_timeout 360;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param HTTPS $fcgi_https;
+    }
+
+    # Expire rules for static content
+    # Feed
+    location ~* \.(?:rss|atom)$ {
+        expires 1h;
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+        expires 1M;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+
+    # Prevent clients from accessing hidden files (starting with a dot)
+    # This is particularly important if you store .htpasswd files in the site hierarchy
+    # Access to `/.well-known/` is allowed.
+    # https://www.mnot.net/blog/2010/04/07/well-known
+    # https://tools.ietf.org/html/rfc5785
+    location ~* /\.(?!well-known\/) {
+        deny all;
+    }
+
+    # Prevent clients from accessing to backup/config/source files
+    location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+        deny all;
+    }
+
+    ## Regular private file serving (i.e. handled by Drupal).
+    location ^~ /system/files/ {
+        ## For not signaling a 404 in the error log whenever the
+        ## system/files directory is accessed add the line below.
+        ## Note that the 404 is the intended behavior.
+        log_not_found off;
+        access_log off;
+        expires 30d;
+        try_files $uri @rewrite;
+    }
+
+    ## provide a health check endpoint
+    location /healthcheck {
+        access_log off;
+        stub_status     on;
+        keepalive_timeout 0;    # Disable HTTP keepalive
+        return 200;
+    }
+
+    error_page 400 401 /40x.html;
+    location = /40x.html {
+            root   /usr/share/nginx/html;
+    }
+
+    location ~ ^/(fpmstatus|ping)$ {
+         access_log off;
+         stub_status     on;
+         keepalive_timeout 0;    # Disable HTTP keepalive
+         allow 127.0.0.1;
+         allow all;
+         fastcgi_index index.php;
+         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+         include fastcgi_params;
+         fastcgi_pass unix:/run/php-fpm.sock;
+    }
+
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,11 @@ html/sites/default/settings.local.php
 
 # Ignore local behat.yml
 behat.yml
+
+
+# Ingore Lando-files
+/app
+
+
+# Ingore DDEV-files
+.ddev/docker-compose.yaml

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,144 @@
+# Drupal 8 recipe
+name: dnorge
+
+# Start with the default Drupal 8 recipe
+recipe: drupal8
+
+# Configure the Drupal8 recipe
+config:
+
+  # See: https://www.drupal.org/docs/8/system-requirements
+
+  # Optionally specify the php version to use.
+  #
+  # If ommitted this will default to the latest php version supported by Drupal 8.
+  # Consult the `php` service to see what versions are available. Note that all
+  # such versions may not be supported in Drupal 8s so YMMV.
+  #
+  # See: https://www.drupal.org/docs/8/system-requirements/php
+  #
+  # NOTE: that this needs to be wrapped in quotes so that it is a string
+  #
+  php: '7.1'
+
+  # Optionally specify whether you want to serve drupal via nginx or apache
+  #
+  # If ommitted this will default to the latest apache
+  #
+  # See: https://www.drupal.org/docs/8/system-requirements/web-server
+  #
+  via: nginx
+
+  # Optionally specify the location of the webroot relative to your approot.
+  #
+  # If ommitted this will be your approot itself.
+  #
+  webroot: html/
+
+  # Optionally specify how you want Lando to handle Drush. There are a few options
+  #
+  # If omitted this will install the Drush Launcher and assume you've installed a
+  # site-local version of Drush with Composer
+  #
+  # You can also configure it in the following ways:
+  #
+  # 1. Install via Composer
+  #
+  # This will install the Drush Launcher (https://github.com/drush-ops/drush-launcher)
+  # and will delegate to the site-local version of Drush you've installed with Composer
+  # http://docs.drush.org/en/master/install/
+  # drush: composer
+  #
+  # 2. Install Globally
+  #
+  # This will globally install the corresponding Drush 8 PHAR posted over at
+  # https://github.com/drush-ops/drush/releases
+  # drush: global:8.1.12
+  #
+  # This will ATTEMPT to globally install any pre Drush 8 versions via Composer
+  # drush: global:~7
+  #
+  # 3. Specify a path
+  #
+  # This assumes the user has already installed Drush but wishes to tell Lando where
+  # it exists.
+  # drush: path:/app/vendor/bin/drush
+  #
+  # 4. Do nothing
+  #
+  # This will tell Lando to not do anything, e.g. it's up to the user
+  # drush: false
+  #
+  drush: composer
+
+  # Optionally specify whether you want to disable the global install of drupal console.
+  #
+  # You should also consider a site-local install of drupal console via composer
+  #
+  # See: https://hechoendrupal.gitbooks.io/drupal-console/content/en/getting/composer.html
+  #
+  # drupal: false
+
+  # Optionally specify the database type, this can be one of:
+  #
+  #   - `mysql`
+  #   - `mariadb`
+  #   - `postgres`
+  #
+  # If ommitted this will default to the latest mysql. You can additionally provide
+  # a version with `type:version` but you will need to consult the documentation
+  # for the correct DB service to see what versions are available
+  #
+  # see: https://www.drupal.org/docs/8/system-requirements/database-server
+  #
+  database: mariadb
+
+  # Optionally activate xdebug
+  #
+  # If you are having trouble getting xdebug to work please see:
+  # https://docs.devwithlando.io/services/php.html#using-xdebug
+  xdebug: true
+
+  # Optionally mix in your own config files
+  #
+  # If ommitted this will use "sane defaults" for your recipe type
+  # conf:
+
+    # For more information on setting these files check out the documentation
+    # and examples
+    #
+    # Docs: https://docs.devwithlando.io/services/php.html
+    # Examples: https://github.com/lando/lando/tree/master/examples
+    #
+    # server: config/drupal8.conf
+    # php: config/php.ini
+
+    # For more information on setting these files check out the documentation
+    # and examples for the relevant services:
+    #
+    # MySQL: https://docs.devwithlando.io/services/mysql.html
+    # MariaDB: https://docs.devwithlando.io/services/mariadb.html
+    # PostGres: https://docs.devwithlando.io/services/postgres.html
+    #
+    # Examples: https://github.com/lando/lando/tree/master/examples
+    #
+    # database: config/mysql
+    
+
+# Configure services to Drupal8
+services:
+
+  # PhpMyAdmin
+  # Add a phpmyadmin db frontend
+  pma:
+
+    # Use the latest stable version of phpmyadmin
+    type: phpmyadmin
+
+    # The databases you want to look at, this will default to a service called
+    # "database"
+    #
+    # You might want to run `lando info` on your app to see what databases you
+    # have available    
+    hosts:
+      - database

--- a/README.md
+++ b/README.md
@@ -4,19 +4,43 @@
 
 ## Installation
 
-Clone this repository. For example with:
-
-`git clone git@github.com:drupalnorge/drupalnorge-social.git`
+There is three different ways based on your development environment.
 
 If you want a database dump, here is one: [https://drupalnorge.no/sanitized.db](https://drupalnorge.no/sanitized.db)
 
-`cd` into the repository root. Install the composer dependencies. For example with:
+### a) Your own development environment
 
-`composer install`
+1. Clone this repository. For example with: `git clone git@github.com:drupalnorge/drupalnorge-social.git`
 
-Install drupal. You can do this however you want. One way is to use drush:
+2. `cd` into the repository root. Install the composer dependencies. For example with: `composer install`
 
-`drush site-install --db-url=mysql://USER:PASS@HOST/DATABASE`
+3. Install drupal. You can do this however you want. One way is to use drush: `drush site-install --db-url=mysql://USER:PASS@HOST/DATABASE`
+
+
+
+### b) Using *Lando* as a development environment
+
+We have a ready configuration file for _[Lando development environment](https://docs.devwithlando.io)_ for you. However, you can change the configuration `.lando.yml`-file you want.
+
+1. Clone this repository. For example with: `git clone git@github.com:drupalnorge/drupalnorge-social.git`
+
+2. `cd` into the repository root. Install the composer dependencies. For example with: `lando composer install`
+
+3. Install drupal. You can do this however you want. One way is to use drush: `lando drush site-install --db-url=mysql://USER:PASS@HOST/DATABASE`
+
+
+
+### c) Using *DDEV* as a development environment
+
+We have a ready configuration file for _[DDEV development environment](https://docs.devwithlando.io)_ for you. However, you can change the configuration `.ddev/.config.yaml`-file you want.
+
+1. Clone this repository. For example with: `git clone git@github.com:drupalnorge/drupalnorge-social.git`
+
+2. `cd` into the repository root. Install the composer dependencies. For example with: `lando composer install`
+
+3. Install drupal. You can do this however you want. One way is to use drush: `lando drush site-install --db-url=mysql://USER:PASS@HOST/DATABASE`
+
+
 
 ## Upgrading open social
 


### PR DESCRIPTION
I have added ready development environment for [Lando](http://devwithlando.io) and [DDEV](https://ddev.readthedocs.io).

I was thinking to make easier for those who want to contribute drupalnorge.no if we have a ready environment for them which can save their time and they can just go straight with fixing the site, testing the patch or helping us to improve the website etc.

Please correct the environment configurations if there is something I am missing in Lando and DDEV.

I hope it helps. 😄 