### PR TITLE
Remove the specific ports for DDEV development environment

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -3,8 +3,8 @@ name: dnorge
 type: drupal8
 docroot: "html/"
 php_version: "7.1"
-router_http_port: "8000"
-router_https_port: "8443"
+# router_http_port: "8000"
+# router_https_port: "8443"
 xdebug_enabled: true
 additional_hostnames: []
 provider: default


### PR DESCRIPTION
Remove the specific ports for http&https for DDEV development environment. If they have a problem with the web-ports, then they can uncomment it.